### PR TITLE
removed hard dependency on backbone

### DIFF
--- a/backbone.nativeview.js
+++ b/backbone.nativeview.js
@@ -6,164 +6,179 @@
 //     For all details and documentation:
 //     https://github.com/akre54/Backbone.NativeView
 
-(function (factory) {
-  if (typeof define === 'function' && define.amd) { define(['backbone'], factory);
-  } else if (typeof exports === 'object') { factory(require('backbone'));
-  } else { factory(Backbone); }
-}(function (Backbone) {
-  // Cached regex to match an opening '<' of an HTML tag, possibly left-padded
-  // with whitespace.
-  var paddedLt = /^\s*</;
+(function () {
 
-  // Caches a local reference to `Element.prototype` for faster access.
-  var ElementProto = (typeof Element !== 'undefined' && Element.prototype) || {};
+  var factory = function (Backbone) {
+    // Cached regex to match an opening '<' of an HTML tag, possibly left-padded
+    // with whitespace.
+    var paddedLt = /^\s*</;
 
-  // Cross-browser event listener shims
-  var elementAddEventListener = ElementProto.addEventListener || function(eventName, listener) {
-    return this.attachEvent('on' + eventName, listener);
-  }
-  var elementRemoveEventListener = ElementProto.removeEventListener || function(eventName, listener) {
-    return this.detachEvent('on' + eventName, listener);
-  }
+    // Caches a local reference to `Element.prototype` for faster access.
+    var ElementProto = (typeof Element !== 'undefined' && Element.prototype) || {};
 
-  var indexOf = function(array, item) {
-    for (var i = 0, len = array.length; i < len; i++) if (array[i] === item) return i;
-    return -1;
-  }
+    // Cross-browser event listener shims
+    var elementAddEventListener = ElementProto.addEventListener || function(eventName, listener) {
+      return this.attachEvent('on' + eventName, listener);
+    }
+    var elementRemoveEventListener = ElementProto.removeEventListener || function(eventName, listener) {
+      return this.detachEvent('on' + eventName, listener);
+    }
 
-  // Find the right `Element#matches` for IE>=9 and modern browsers.
-  var matchesSelector = ElementProto.matches ||
-      ElementProto.webkitMatchesSelector ||
-      ElementProto.mozMatchesSelector ||
-      ElementProto.msMatchesSelector ||
-      ElementProto.oMatchesSelector ||
-      // Make our own `Element#matches` for IE8
-      function(selector) {
-        // Use querySelectorAll to find all elements matching the selector,
-        // then check if the given element is included in that list.
-        // Executing the query on the parentNode reduces the resulting nodeList,
-        // (document doesn't have a parentNode).
-        var nodeList = (this.parentNode || document).querySelectorAll(selector) || [];
-        return ~indexOf(nodeList, this);
-      };
+    var indexOf = function(array, item) {
+      for (var i = 0, len = array.length; i < len; i++) if (array[i] === item) return i;
+      return -1;
+    }
 
-  // Cache Backbone.View for later access in constructor
-  var BBView = Backbone.View;
+    // Find the right `Element#matches` for IE>=9 and modern browsers.
+    var matchesSelector = ElementProto.matches ||
+        ElementProto.webkitMatchesSelector ||
+        ElementProto.mozMatchesSelector ||
+        ElementProto.msMatchesSelector ||
+        ElementProto.oMatchesSelector ||
+        // Make our own `Element#matches` for IE8
+        function(selector) {
+          // Use querySelectorAll to find all elements matching the selector,
+          // then check if the given element is included in that list.
+          // Executing the query on the parentNode reduces the resulting nodeList,
+          // (document doesn't have a parentNode).
+          var nodeList = (this.parentNode || document).querySelectorAll(selector) || [];
+          return ~indexOf(nodeList, this);
+        };
 
-  // To extend an existing view to use native methods, extend the View prototype
-  // with the mixin: _.extend(MyView.prototype, Backbone.NativeViewMixin);
-  Backbone.NativeViewMixin = {
+    // Cache Backbone.View for later access in constructor
+    var BBView = Backbone.View;
 
-    _domEvents: null,
+    // To extend an existing view to use native methods, extend the View prototype
+    // with the mixin: _.extend(MyView.prototype, Backbone.NativeViewMixin);
+    Backbone.NativeViewMixin = {
 
-    constructor: function() {
-      this._domEvents = [];
-      return BBView.apply(this, arguments);
-    },
+      _domEvents: null,
 
-    $: function(selector) {
-      return this.el.querySelectorAll(selector);
-    },
+      constructor: function() {
+        this._domEvents = [];
+        return BBView.apply(this, arguments);
+      },
 
-    _removeElement: function() {
-      this.undelegateEvents();
-      if (this.el.parentNode) this.el.parentNode.removeChild(this.el);
-    },
+      $: function(selector) {
+        return this.el.querySelectorAll(selector);
+      },
 
-    // Apply the `element` to the view. `element` can be a CSS selector,
-    // a string of HTML, or an Element node.
-    _setElement: function(element) {
-      if (typeof element == 'string') {
-        if (paddedLt.test(element)) {
-          var el = document.createElement('div');
-          el.innerHTML = element;
-          this.el = el.firstChild;
+      _removeElement: function() {
+        this.undelegateEvents();
+        if (this.el.parentNode) this.el.parentNode.removeChild(this.el);
+      },
+
+      // Apply the `element` to the view. `element` can be a CSS selector,
+      // a string of HTML, or an Element node.
+      _setElement: function(element) {
+        if (typeof element == 'string') {
+          if (paddedLt.test(element)) {
+            var el = document.createElement('div');
+            el.innerHTML = element;
+            this.el = el.firstChild;
+          } else {
+            this.el = document.querySelector(element);
+          }
         } else {
-          this.el = document.querySelector(element);
+          this.el = element;
         }
-      } else {
-        this.el = element;
-      }
-    },
+      },
 
-    // Set a hash of attributes to the view's `el`. We use the "prop" version
-    // if available, falling back to `setAttribute` for the catch-all.
-    _setAttributes: function(attrs) {
-      for (var attr in attrs) {
-        attr in this.el ? this.el[attr] = attrs[attr] : this.el.setAttribute(attr, attrs[attr]);
-      }
-    },
+      // Set a hash of attributes to the view's `el`. We use the "prop" version
+      // if available, falling back to `setAttribute` for the catch-all.
+      _setAttributes: function(attrs) {
+        for (var attr in attrs) {
+          attr in this.el ? this.el[attr] = attrs[attr] : this.el.setAttribute(attr, attrs[attr]);
+        }
+      },
 
-    // Make a event delegation handler for the given `eventName` and `selector`
-    // and attach it to `this.el`.
-    // If selector is empty, the listener will be bound to `this.el`. If not, a
-    // new handler that will recursively traverse up the event target's DOM
-    // hierarchy looking for a node that matches the selector. If one is found,
-    // the event's `delegateTarget` property is set to it and the return the
-    // result of calling bound `listener` with the parameters given to the
-    // handler.
-    delegate: function(eventName, selector, listener) {
-      if (typeof selector === 'function') {
-        listener = selector;
-        selector = null;
-      }
+      // Make a event delegation handler for the given `eventName` and `selector`
+      // and attach it to `this.el`.
+      // If selector is empty, the listener will be bound to `this.el`. If not, a
+      // new handler that will recursively traverse up the event target's DOM
+      // hierarchy looking for a node that matches the selector. If one is found,
+      // the event's `delegateTarget` property is set to it and the return the
+      // result of calling bound `listener` with the parameters given to the
+      // handler.
+      delegate: function(eventName, selector, listener) {
+        if (typeof selector === 'function') {
+          listener = selector;
+          selector = null;
+        }
 
-      var root = this.el;
-      var handler = selector ? function (e) {
-        var node = e.target || e.srcElement;
-        for (; node && node != root; node = node.parentNode) {
-          if (matchesSelector.call(node, selector)) {
-            e.delegateTarget = node;
-            listener(e);
+        var root = this.el;
+        var handler = selector ? function (e) {
+          var node = e.target || e.srcElement;
+          for (; node && node != root; node = node.parentNode) {
+            if (matchesSelector.call(node, selector)) {
+              e.delegateTarget = node;
+              listener(e);
+            }
+          }
+        } : listener;
+
+        elementAddEventListener.call(this.el, eventName, handler, false);
+        this._domEvents.push({eventName: eventName, handler: handler, listener: listener, selector: selector});
+        return handler;
+      },
+
+      // Remove a single delegated event. Either `eventName` or `selector` must
+      // be included, `selector` and `listener` are optional.
+      undelegate: function(eventName, selector, listener) {
+        if (typeof selector === 'function') {
+          listener = selector;
+          selector = null;
+        }
+
+        if (this.el) {
+          var handlers = this._domEvents.slice();
+          for (var i = 0, len = handlers.length; i < len; i++) {
+            var item = handlers[i];
+
+            var match = item.eventName === eventName &&
+                (listener ? item.listener === listener : true) &&
+                (selector ? item.selector === selector : true);
+
+            if (!match) continue;
+
+            elementRemoveEventListener.call(this.el, item.eventName, item.handler, false);
+            this._domEvents.splice(indexOf(handlers, item), 1);
           }
         }
-      } : listener;
+        return this;
+      },
 
-      elementAddEventListener.call(this.el, eventName, handler, false);
-      this._domEvents.push({eventName: eventName, handler: handler, listener: listener, selector: selector});
-      return handler;
-    },
-
-    // Remove a single delegated event. Either `eventName` or `selector` must
-    // be included, `selector` and `listener` are optional.
-    undelegate: function(eventName, selector, listener) {
-      if (typeof selector === 'function') {
-        listener = selector;
-        selector = null;
-      }
-
-      if (this.el) {
-        var handlers = this._domEvents.slice();
-        for (var i = 0, len = handlers.length; i < len; i++) {
-          var item = handlers[i];
-
-          var match = item.eventName === eventName &&
-              (listener ? item.listener === listener : true) &&
-              (selector ? item.selector === selector : true);
-
-          if (!match) continue;
-
-          elementRemoveEventListener.call(this.el, item.eventName, item.handler, false);
-          this._domEvents.splice(indexOf(handlers, item), 1);
+      // Remove all events created with `delegate` from `el`
+      undelegateEvents: function() {
+        if (this.el) {
+          for (var i = 0, len = this._domEvents.length; i < len; i++) {
+            var item = this._domEvents[i];
+            elementRemoveEventListener.call(this.el, item.eventName, item.handler, false);
+          };
+          this._domEvents.length = 0;
         }
+        return this;
       }
-      return this;
-    },
+    };
 
-    // Remove all events created with `delegate` from `el`
-    undelegateEvents: function() {
-      if (this.el) {
-        for (var i = 0, len = this._domEvents.length; i < len; i++) {
-          var item = this._domEvents[i];
-          elementRemoveEventListener.call(this.el, item.eventName, item.handler, false);
-        };
-        this._domEvents.length = 0;
-      }
-      return this;
-    }
+    Backbone.NativeView = Backbone.View.extend(Backbone.NativeViewMixin);
+
+    return Backbone.NativeView;
   };
 
-  Backbone.NativeView = Backbone.View.extend(Backbone.NativeViewMixin);
 
-  return Backbone.NativeView;
-}));
+  if (typeof define === 'function' && define.amd) {
+    define([], function () {
+      return factory;
+    });
+  } else if (typeof exports === 'object') {
+    module.exports = factory;
+  } else {
+    if (Backbone) {
+      factory(Backbone);
+    } else {
+      throw 'Backbone.NativeView expects an instance of Backbone to be present';
+    }
+  }
+
+}());


### PR DESCRIPTION
Here (mainly at the bottom of the file) is the best implementation I can think of. It's not ideal because
 - in amd/commonjs it exports a function which the developer must pass Backbone/exoskeleton to
 - in the browser it runs itself on Backbone (if it finds it)

I don't like the difference in API between the two, but can't think of a better solution.