### PR TITLE
Use i instead of indexOf function call for splice

### DIFF
--- a/backbone.nativeview.js
+++ b/backbone.nativeview.js
@@ -144,7 +144,7 @@
           if (!match) continue;
 
           elementRemoveEventListener.call(this.el, item.eventName, item.handler, false);
-          this._domEvents.splice(indexOf(handlers, item), 1);
+          this._domEvents.splice(i, 1);
         }
       }
       return this;


### PR DESCRIPTION
This is a basic optimization to using the current loop iteration variable i instead of the indexOf lookup for splicing the array of cached events.  A micro-optimization for small arrays, but will scale much better for large arrays of events.