### PR TITLE
Use while loop with decrement to avoid reindexing issues

### DIFF
--- a/backbone.nativeview.js
+++ b/backbone.nativeview.js
@@ -134,7 +134,8 @@
 
       if (this.el) {
         var handlers = this._domEvents.slice();
-        for (var i = 0, len = handlers.length; i < len; i++) {
+        var i = handlers.length;
+        while (i--) {
           var item = handlers[i];
 
           var match = item.eventName === eventName &&


### PR DESCRIPTION
Fixes the issue with sequential events being missed in #17 during undelegate() by looping the array in reverse order.