### PR TITLE
#setElement should handle array-likes

### DIFF
--- a/backbone.nativeview.js
+++ b/backbone.nativeview.js
@@ -81,6 +81,8 @@
         } else {
           this.el = document.querySelector(element);
         }
+      } else if (element && element.length) {
+        this.el = element[0];
       } else {
         this.el = element;
       }

--- a/test/nativeview.js
+++ b/test/nativeview.js
@@ -33,6 +33,12 @@
     equal(result[0].tagName.toLowerCase(), 'h1');
     equal(result[0].nodeType, 1);
   });
+  
+  test("View#setElement", function() {
+    var result = view.$('h1');
+    view.setElement(result);
+    equal(view.el, result[0]);
+  });
 
   test("delegate and undelegate", 6, function() {
     var counter1 = 0, counter2 = 0;


### PR DESCRIPTION
This allows views to directly pass `this.$('selector')` to a subview's constructor or directly to `#setElement`:

```js
var View = Backbone.View.extend({
  render: function() {
    // Do something...
    // Attach a subview to this view's element
    var subView = new SubView({
      el: this.$('.selector')
    });

    // Or...
    subview.setElement(this.$('.selector'));
  }
});