### PR TITLE
Avoid setting `this.el` to child node of element

### DIFF
--- a/backbone.nativeview.js
+++ b/backbone.nativeview.js
@@ -87,7 +87,7 @@
         } else {
           this.el = document.querySelector(element);
         }
-      } else if (element && element.length) {
+      } else if (element && !_.isElement(element) && element.length) {
         this.el = element[0];
       } else {
         this.el = element;

--- a/backbone.nativeview.js
+++ b/backbone.nativeview.js
@@ -7,10 +7,10 @@
 //     https://github.com/akre54/Backbone.NativeView
 
 (function (factory) {
-  if (typeof define === 'function' && define.amd) { define(['backbone'], factory);
-  } else if (typeof module === 'object') { module.exports = factory(require('backbone'));
-  } else { factory(Backbone); }
-}(function (Backbone) {
+  if (typeof define === 'function' && define.amd) { define(['underscore', 'backbone'], factory);
+  } else if (typeof module === 'object') { module.exports = factory(require('underscore'), require('backbone'));
+  } else { factory(_, Backbone); }
+}(function (_, Backbone) {
   // Cached regex to match an opening '<' of an HTML tag, possibly left-padded
   // with whitespace.
   var paddedLt = /^\s*</;


### PR DESCRIPTION
In `_setElement`, when an element containing child nodes is passed in, we still want to set the entire element, and not `element[0]`.